### PR TITLE
content: add --relay argument to ticket creation on couple of blog posts

### DIFF
--- a/src/content/blog/announcing_influxdb_addon.mdx
+++ b/src/content/blog/announcing_influxdb_addon.mdx
@@ -88,7 +88,7 @@ ockam identity create connected-vehicle
 Identity created, we can authenticate to our project using the enrolment token SENSOR_TICKET we saved at the start of this section:
 
 ```bash
-ockam project enroll $VEHCILE_TICKET \
+ockam project enroll $VEHICLE_TICKET \
   --identity connected-vehicle
 ```
 

--- a/src/content/blog/connect_private_influxdb.mdx
+++ b/src/content/blog/connect_private_influxdb.mdx
@@ -149,7 +149,7 @@ The first step is to enroll yourself with Ockam, and create enrollment tokens fo
 ```bash
 ockam enroll
 export OCKAM_INFLUXDB_TICKET=$( \
-  ockam project ticket --attribute component=influxdb)
+  ockam project ticket --attribute component=influxdb --relay "influxdb")
 export OCKAM_TELEGRAF_TICKET=$( \
   ockam project ticket --attribute component=telegraf)
 ```

--- a/src/content/blog/okta.mdx
+++ b/src/content/blog/okta.mdx
@@ -210,11 +210,12 @@ This will create a managed Credential Authority for our project.
 
 Next we generate two one-time-use enrollment tokens to enable Machine 1 and 2 to enroll
 and get credentials. Notice how we specify the attributes to attest for these two
-machines: `city` and `application`.
+machines: `city` and `application`.  We also specify the name of the relays on orchestrator that these
+machines can create: "m1" and "m2" respectively.
 
 ```bash
-m1_token=$(ockam project ticket --attribute application="Smart Factory" --attribute city="San Francisco")
-m2_token=$(ockam project ticket --attribute application="Smart Factory" --attribute city="New York")
+m1_token=$(ockam project ticket --attribute application="Smart Factory" --attribute city="San Francisco" --relay "m1")
+m2_token=$(ockam project ticket --attribute application="Smart Factory" --attribute city="New York" --relay "m2")
 ```
 
 ### Machine 1 in New York


### PR DESCRIPTION
where needed, announcing-influx-addon for example doesn't need it as users of the tickets doesn't need to create relays.
Tried to use a more specific --relay than "*" where possible.