### PR TITLE
fix: hover style and mobile stylings for cards

### DIFF
--- a/src/components/mdx/SideBySidePanel.tsx
+++ b/src/components/mdx/SideBySidePanel.tsx
@@ -50,6 +50,7 @@ const SideBySidePanel: FC<Props> = ({
   const panelProps = (): {} => {
     if (!isPanel)
       return {
+        border: '2px solid transparent',
         mb: { base: '32' },
         px: { base: '8', lg: '0' },
         width: width || '100%',
@@ -60,8 +61,8 @@ const SideBySidePanel: FC<Props> = ({
         backgroundColor: 'white',
         boxShadow: '2xl',
         overflow: 'hidden',
-        transition: 'border-color 2s linear',
-        border: '2px solid none',
+        transition: 'all 0.3s linear',
+        border: '2px solid transparent',
         px: { base: '8', lg: '8' },
         py: { base: '8', lg: '8' },
         mx: { base: '0' },
@@ -81,7 +82,7 @@ const SideBySidePanel: FC<Props> = ({
   const hoverStyle = (): {} => {
     if (isMinimal && href)
       return {
-        borderColor: theme.colors.brand[500],
+        borderColor: theme.colors.gray[200],
         boxShadow: 'xl',
       };
     return {};

--- a/src/components/mdx/SideBySidePanel.tsx
+++ b/src/components/mdx/SideBySidePanel.tsx
@@ -59,7 +59,7 @@ const SideBySidePanel: FC<Props> = ({
       return {
         borderRadius: { sm: 0, md: '2xl' },
         backgroundColor: 'white',
-        boxShadow: '2xl',
+        boxShadow: { base: 'none', md: '2xl' },
         overflow: 'hidden',
         transition: 'all 0.3s linear',
         border: '2px solid transparent',
@@ -82,8 +82,8 @@ const SideBySidePanel: FC<Props> = ({
   const hoverStyle = (): {} => {
     if (isMinimal && href)
       return {
-        borderColor: theme.colors.gray[200],
-        boxShadow: 'xl',
+        borderColor: { base: 'transparent', md: theme.colors.gray[200] },
+        boxShadow: { base: 'none', md: 'xl' },
       };
     return {};
   };

--- a/src/views/homepage/Cases.tsx
+++ b/src/views/homepage/Cases.tsx
@@ -135,11 +135,11 @@ const Cases: FunctionComponent<FlexProps> = ({ ...restProps }) => (
       />
     </GradientContainer>
 
-    <Container variant="section" pt={{ base: 0, lg: 0 }} pb={{ base: 12, lg: 12 }} px={0} mt={16}>
+    <Container variant="section" pt={{ base: 0, lg: 0 }} px={0} mt={16}>
       <Flex
         direction="row"
         width="100%"
-        gap={{ base: '4', md: '4' }}
+        gap={{ base: 0, md: '4' }}
         alignItems="stretch"
         flexWrap="wrap"
         justify="space-around"
@@ -149,7 +149,6 @@ const Cases: FunctionComponent<FlexProps> = ({ ...restProps }) => (
             width={{ base: '100%', md: '45%', lg: '45%', xl: '24%' }}
             minW="300px"
             key={`case-${item.title}`}
-            my={{ base: '4', md: '0' }}
           >
             <Transition key={item.title} delay={(index + 1) * 300} duration={500} height="100%">
               <CasesCard {...item} textOrientation="left" />


### PR DESCRIPTION
- added hover style for card
- updated RWD for cards section

# Screenshots:
Hover:
<img width="416" alt="Screenshot 2024-06-04 at 12 39 33" src="https://github.com/build-trust/ockam-website/assets/9156506/b16201e6-6983-48c3-8162-05c532ccd249">

RWD:
<img width="305" alt="Screenshot 2024-06-04 at 12 39 54" src="https://github.com/build-trust/ockam-website/assets/9156506/e9308ec9-f566-445c-9ec7-81745d8ed06e">

